### PR TITLE
feat: added banner and update subscription check to make maintained actions free for public repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![StepSecurity Maintained Action](https://raw.githubusercontent.com/step-security/maintained-actions-assets/main/assets/maintained-action-banner.png)](https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions)
+
 # GitHub Action: Run tflint with reviewdog
 
 This action runs [tflint](https://github.com/wata727/tflint) with

--- a/action.yml
+++ b/action.yml
@@ -82,6 +82,49 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Subscription check
+      env:
+        REPO_PRIVATE: ${{ github.event.repository.private }}
+      run: |
+        UPSTREAM="reviewdog/action-tflint"
+        ACTION_REPO="${GITHUB_ACTION_REPOSITORY:-}"
+        DOCS_URL="https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions"
+
+        echo ""
+        echo -e "\033[1;36mStepSecurity Maintained Action\033[0m"
+        echo "Secure drop-in replacement for $UPSTREAM"
+        if [ "$REPO_PRIVATE" = "false" ]; then
+          echo -e "\033[32m✓ Free for public repositories\033[0m"
+        fi
+        echo -e "\033[36mLearn more:\033[0m $DOCS_URL"
+        echo ""
+
+        if [ "$REPO_PRIVATE" != "false" ]; then
+          SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
+
+          if [ "$SERVER_URL" != "https://github.com" ]; then
+            BODY=$(printf '{"action":"%s","ghes_server":"%s"}' "$ACTION_REPO" "$SERVER_URL")
+          else
+            BODY=$(printf '{"action":"%s"}' "$ACTION_REPO")
+          fi
+
+          API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/maintained-actions-subscription"
+
+          RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            "$API_URL" -o /dev/null) && CURL_EXIT_CODE=0 || CURL_EXIT_CODE=$?
+
+          if [ $CURL_EXIT_CODE -ne 0 ]; then
+            echo "Timeout or API not reachable. Continuing to next step."
+          elif [ "$RESPONSE" = "403" ]; then
+            echo -e "::error::\033[1;31mThis action requires a StepSecurity subscription for private repositories.\033[0m"
+            echo -e "::error::\033[31mLearn how to enable a subscription: $DOCS_URL\033[0m"
+            exit 1
+          fi
+        fi
+      shell: bash
     - run: $GITHUB_ACTION_PATH/script.sh
       id: tflint
       shell: bash

--- a/script.sh
+++ b/script.sh
@@ -1,45 +1,4 @@
 #!/bin/bash
-
-REPO_PRIVATE=$(jq -r '.repository.private | tostring' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "")
-UPSTREAM="reviewdog/action-tflint"
-ACTION_REPO="${GITHUB_ACTION_REPOSITORY:-}"
-DOCS_URL="https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions"
-
-echo ""
-echo -e "\033[1;36mStepSecurity Maintained Action\033[0m"
-echo "Secure drop-in replacement for $UPSTREAM"
-if [ "$REPO_PRIVATE" = "false" ]; then
-  echo -e "\033[32m✓ Free for public repositories\033[0m"
-fi
-echo -e "\033[36mLearn more:\033[0m $DOCS_URL"
-echo ""
-
-if [ "$REPO_PRIVATE" != "false" ]; then
-  SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
-
-  if [ "$SERVER_URL" != "https://github.com" ]; then
-    BODY=$(printf '{"action":"%s","ghes_server":"%s"}' "$ACTION_REPO" "$SERVER_URL")
-  else
-    BODY=$(printf '{"action":"%s"}' "$ACTION_REPO")
-  fi
-
-  API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/maintained-actions-subscription"
-
-  RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" \
-    -X POST \
-    -H "Content-Type: application/json" \
-    -d "$BODY" \
-    "$API_URL" -o /dev/null) && CURL_EXIT_CODE=0 || CURL_EXIT_CODE=$?
-
-  if [ $CURL_EXIT_CODE -ne 0 ]; then
-    echo "Timeout or API not reachable. Continuing to next step."
-  elif [ "$RESPONSE" = "403" ]; then
-    echo -e "::error::\033[1;31mThis action requires a StepSecurity subscription for private repositories.\033[0m"
-    echo -e "::error::\033[31mLearn how to enable a subscription: $DOCS_URL\033[0m"
-    exit 1
-  fi
-fi
-
 # Fail fast on errors, unset variables, and failures in piped commands
 set -Eeuo pipefail
 

--- a/script.sh
+++ b/script.sh
@@ -1,22 +1,43 @@
 #!/bin/bash
 
-# validate subscription status
-API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/subscription"
+REPO_PRIVATE=$(jq -r '.repository.private | tostring' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "")
+UPSTREAM="reviewdog/action-tflint"
+ACTION_REPO="${GITHUB_ACTION_REPOSITORY:-}"
+DOCS_URL="https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions"
 
-# Set a timeout for the curl command (3 seconds)
-RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" "$API_URL" -o /dev/null) || true
-CURL_EXIT_CODE=$?
+echo ""
+echo -e "\033[1;36mStepSecurity Maintained Action\033[0m"
+echo "Secure drop-in replacement for $UPSTREAM"
+if [ "$REPO_PRIVATE" = "false" ]; then
+  echo -e "\033[32m✓ Free for public repositories\033[0m"
+fi
+echo -e "\033[36mLearn more:\033[0m $DOCS_URL"
+echo ""
 
-# Decide based on curl exit code and HTTP status
-if [ $CURL_EXIT_CODE -ne 0 ]; then
-  echo "Timeout or API not reachable. Continuing to next step."
-elif [ "$RESPONSE" = "200" ]; then
-  :
-elif [ "$RESPONSE" = "403" ]; then
-  echo "Subscription is not valid. Reach out to support@stepsecurity.io"
-  exit 1
-else
-  echo "Timeout or API not reachable. Continuing to next step."
+if [ "$REPO_PRIVATE" != "false" ]; then
+  SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
+
+  if [ "$SERVER_URL" != "https://github.com" ]; then
+    BODY=$(printf '{"action":"%s","ghes_server":"%s"}' "$ACTION_REPO" "$SERVER_URL")
+  else
+    BODY=$(printf '{"action":"%s"}' "$ACTION_REPO")
+  fi
+
+  API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/maintained-actions-subscription"
+
+  RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d "$BODY" \
+    "$API_URL" -o /dev/null) && CURL_EXIT_CODE=0 || CURL_EXIT_CODE=$?
+
+  if [ $CURL_EXIT_CODE -ne 0 ]; then
+    echo "Timeout or API not reachable. Continuing to next step."
+  elif [ "$RESPONSE" = "403" ]; then
+    echo -e "::error::\033[1;31mThis action requires a StepSecurity subscription for private repositories.\033[0m"
+    echo -e "::error::\033[31mLearn how to enable a subscription: $DOCS_URL\033[0m"
+    exit 1
+  fi
 fi
 
 # Fail fast on errors, unset variables, and failures in piped commands


### PR DESCRIPTION
## Summary

- Added StepSecurity Maintained Action banner to README.md
- Updated subscription validation: public repositories are now free (no API check)
- Updated subscription check in both action.yml (composite step) and script.sh

## Changes by type
- **Composite actions**: added Subscription check step to action.yml, updated script.sh subscription block

## Verification
- [ ] Subscription check skips for public repos
- [ ] Subscription check fires for private repos
- [ ] README banner is present at the top
- [ ] Build passes (TS/JS actions)

Auto-generated by StepSecurity update-propagator. Task ID: 20260420T074543Z